### PR TITLE
Update plugin.yml for 1.16

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DiscordBridge
 main: fwcd.mcdiscordbridge.plugin.DiscordBridgePlugin
-version: 0.1
-api-version: 1.15
+version: 0.2
+api-version: 1.16
 softdepend: [dynmap]


### PR DESCRIPTION
Logger appears to be broken:
```
[17:03:55] [Server thread/INFO]: [DiscordBridge] Enabling DiscordBridge v0.2
[17:03:55] [Server thread/INFO]: [DiscordBridge] Starting Discord bridge...
[17:03:56] [Server thread/WARN]: SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[17:03:56] [Server thread/WARN]: SLF4J: Defaulting to no-operation (NOP) logger implementation
[17:03:56] [Server thread/WARN]: SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[17:03:59] [Server thread/WARN]: SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
[17:03:59] [Server thread/WARN]: SLF4J: Defaulting to no-operation MDCAdapter implementation.
[17:03:59] [Server thread/WARN]: SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
[17:03:59] [Server thread/WARN]: [Server thread] INFO JDA - Login Successful!
[17:03:59] [Server thread/INFO]: [DiscordBridge] Skipping Dynmap integration
```